### PR TITLE
8 use mkoutofstoresymlink to link scripts to localbin

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -207,7 +207,8 @@
 
   programs.pgcli.enable = true;
 
-  home.file.".local/bin".source = config.lib.file.mkOutOfStoreSymlink ./scripts;
+  home.file.".local/bin".source =
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.config/home-manager/scripts";
 
   home.sessionPath = [
     "$HOME/.local/bin"

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   username,
   nixCats-nvim,
@@ -206,12 +207,7 @@
 
   programs.pgcli.enable = true;
 
-  home.file = {
-    ".local/bin" = {
-      source = ./scripts;
-      recursive = true;
-    };
-  };
+  home.file.".local/bin".source = config.lib.file.mkOutOfStoreSymlink ./scripts;
 
   home.sessionPath = [
     "$HOME/.local/bin"


### PR DESCRIPTION
- **fix: make out-of-store symlink for .local/bin -> scripts**
- **fix: use abspath for out-of-store symlink**
